### PR TITLE
Add go-bindata install as dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,5 @@
 ##
 
 sample-config:
+	go get -u github.com/jteeuwen/go-bindata/...
 	cd repo && go-bindata -pkg=repo sample-filehive.conf


### PR DESCRIPTION
This might not be the best option to do this, but let's make it clear that go-bindata is a dependency.